### PR TITLE
Use captured exit code to terminate step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
         fetch-depth: 0
 
     - name: Run render for Rmd
-      uses: ottrproject/ottr-preview@cansavvy/docker-swap
+      uses: ottrproject/ottr-preview@cansavvy/fix-exit-code
       with:
         toggle_website: "rmd"
         root_path: test-rmd
 
     - name: Run render for Quarto
-      uses: ottrproject/ottr-preview@cansavvy/docker-swap
+      uses: ottrproject/ottr-preview@cansavvy/fix-exit-code
       with:
         toggle_website: "quarto"
         root_path: test-quarto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
         fetch-depth: 0
 
     - name: Run render for Rmd
-      uses: ottrproject/ottr-preview@cansavvy/fix-exit-code
+      uses: ottrproject/ottr-preview@fix-exit-code
       with:
         toggle_website: "rmd"
         root_path: test-rmd
 
     - name: Run render for Quarto
-      uses: ottrproject/ottr-preview@cansavvy/fix-exit-code
+      uses: ottrproject/ottr-preview@fix-exit-code
       with:
         toggle_website: "quarto"
         root_path: test-quarto

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,7 @@ runs:
         docker run -v ${{ github.workspace }}/${{ inputs.root_path }}:/home \
           ${{ inputs.docker_image }} bash /home/entrypoint.sh ${{ inputs.toggle_website }} || exit_code=$?
         rm ${{ inputs.root_path }}/entrypoint.sh
+        exit ${exit_code:-0}
       shell: bash
 
     # This checks on the steps before it and makes sure that they completed.


### PR DESCRIPTION
I believe the issue here is that 

```
docker run -v ${{ github.workspace }}/${{ inputs.root_path }}:/home  ${{ inputs.docker_image }} bash /home/entrypoint.sh ${{ inputs.toggle_website }} || exit_code=$?
```

Actually swallows the error code because of the `||` and will always exit 0 (I guess, unless the variable assignment fails somehow). As an example:

<img width="950" alt="Screenshot 2025-05-12 at 8 56 46 PM" src="https://github.com/user-attachments/assets/1e95831d-c953-4dd4-a87b-ee9de28e6e62" />

still prints `hello, world` despite the fact that `cat` failed. This means that in the subsequent check for `'${{steps.render.outcome}}' != 'success'` it will always seem like it succeeded. This change should cause the step to exit with the captured error code (if there was one), and default to `0` otherwise.

closes #6 