### PR TITLE
Don't fail when there's no docx file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
         fetch-depth: 0
 
     - name: Run render for Rmd
-      uses: ottrproject/ottr-preview@cansavvy/docker-swap
+      uses: ottrproject/ottr-preview@cansavvy/no-docx
       with:
         toggle_website: "rmd"
         root_path: test-rmd
 
     - name: Run render for Quarto
-      uses: ottrproject/ottr-preview@cansavvy/docker-swap
+      uses: ottrproject/ottr-preview@cansavvy/no-docx
       with:
         toggle_website: "quarto"
         root_path: test-quarto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 0
 # update for your user name and branch to test
     - name: Run render for Rmd
-      uses: ottrproject/ottr-preview@usrname/your-testing-branch-replace
+      uses: ottrproject/ottr-preview@cansavvy/no-docx
       with:
         toggle_website: "rmd"
         root_path: test-rmd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run render for Rmd
-      uses: ottrproject/ottr-preview@cansavvy/no-docx
+      uses: ottrproject/ottr-preview@usrname/your-testing-branch-replace
       with:
         toggle_website: "rmd"
         root_path: test-rmd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         root_path: test-rmd
 
     - name: Run render for Quarto
-      uses: ottrproject/ottr-preview@usrname/your-testing-branch-replace
+      uses: ottrproject/ottr-preview@cansavvy/no-docx
       with:
         toggle_website: "quarto"
         root_path: test-quarto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-
+# update for your user name and branch to test
     - name: Run render for Rmd
       uses: ottrproject/ottr-preview@usrname/your-testing-branch-replace
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         root_path: test-rmd
 
     - name: Run render for Quarto
-      uses: ottrproject/ottr-preview@cansavvy/no-docx
+      uses: ottrproject/ottr-preview@usrname/your-testing-branch-replace
       with:
         toggle_website: "quarto"
         root_path: test-quarto

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,7 @@ runs:
         git fetch origin
         git pull --rebase --allow-unrelated-histories --strategy-option=ours
         rm -rf docs/*
+      shell: bash
           
     # Run rendering
     - name: Render Special

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: "The docker image that will be used for rendering"
     default: jhudsl/base_ottr:dev
     type: string
+  token: 
+    description: "A GitHub personal access token only needed if preview = 'false'. Needs privileges to merge to main."
+    type: string
 
 runs:
   using: "composite"
@@ -55,7 +58,7 @@ runs:
     - name: Delete old docs/*
       if: ${{ inputs.preview == 'false' }}
       run: |
-        git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
+        git remote set-url origin https://${inputs.token}@github.com/${GITHUB_REPOSITORY}
         git fetch origin
         git pull --rebase --allow-unrelated-histories --strategy-option=ours
         rm -rf docs/*

--- a/action.yml
+++ b/action.yml
@@ -150,7 +150,12 @@ runs:
       if: ${{ inputs.preview == 'true' }}
       id: build-components
       run: |
-        docx_file=$(ls ${{ inputs.root_path }}/docs/*.docx || echo NA)
+        docx_file=$(ls ./docs/*.docx 2>/dev/null | head -1)
+        if [ -n "$docx_file" ]; then
+          docx_link="https://github.com/$GITHUB_REPOSITORY/raw/preview-7/$docx_file"
+        else
+          docx_link="NA"
+        fi
         bookdown_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/${{ inputs.root_path }}/docs/index.html")
         docx_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/$docx_file")
         zip_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/${{ inputs.root_path }}/website-preview.zip")

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
       run: |
         docx_file=$(ls ./docs/*.docx 2>/dev/null | head -1 || true)
         if [ -n "$docx_file" ]; then
-            docx_link="https://github.com/$GITHUB_REPOSITORY/raw/preview-14/$docx_file"
+            docx_link="https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/$docx_file"
         else
             docx_link="NA"
         fi

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,8 @@ inputs:
   token: 
     description: "A GitHub personal access token only needed if preview = 'false'. Needs privileges to merge to main."
     type: string
+  repo: 
+    description: "WHat repo are we merging to? Only needed for 
 
 runs:
   using: "composite"
@@ -58,7 +60,7 @@ runs:
     - name: Delete old docs/*
       if: ${{ inputs.preview == 'false' }}
       run: |
-        git remote set-url origin https://${inputs.token}@github.com/${GITHUB_REPOSITORY}
+        git remote set-url origin https://${{ inputs.token }}@github.com/$GITHUB_REPOSITORY
         git fetch origin
         git pull --rebase --allow-unrelated-histories --strategy-option=ours
         rm -rf docs/*

--- a/action.yml
+++ b/action.yml
@@ -157,7 +157,6 @@ runs:
           docx_link="NA"
         fi
         bookdown_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/${{ inputs.root_path }}/docs/index.html")
-        docx_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/$docx_file")
         zip_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/${{ inputs.root_path }}/website-preview.zip")
         echo "zip_link=$zip_link" >> $GITHUB_OUTPUT
         echo "bookdown_link=$bookdown_link" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
           mv entrypoint.sh ${{ inputs.root_path }}/entrypoint.sh
         fi
         docker run -v ${{ github.workspace }}/${{ inputs.root_path }}:/home \
-          ${{ inputs.docker_image }} bash /home/entrypoint.sh ${{ inputs.toggle_website }}
+          ${{ inputs.docker_image }} bash /home/entrypoint.sh ${{ inputs.toggle_website }} || exit_code=$?
         rm ${{ inputs.root_path }}/entrypoint.sh
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,16 @@ runs:
         git checkout $branch_name
         git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }} --allow-unrelated-histories
       shell: bash
-
+      
+    # We want a fresh run of the renders each time
+    - name: Delete old docs/*
+      if: ${{ inputs.preview == 'false' }}
+      run: |
+        git remote set-url origin https://${GH_PAT}@github.com/${GITHUB_REPOSITORY}
+        git fetch origin
+        git pull --rebase --allow-unrelated-histories --strategy-option=ours
+        rm -rf docs/*
+          
     # Run rendering
     - name: Render Special
       id: render

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,6 @@ inputs:
   token: 
     description: "A GitHub personal access token only needed if preview = 'false'. Needs privileges to merge to main."
     type: string
-  repo: 
-    description: "WHat repo are we merging to? Only needed for 
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -150,11 +150,11 @@ runs:
       if: ${{ inputs.preview == 'true' }}
       id: build-components
       run: |
-        docx_file=$(ls ./docs/*.docx 2>/dev/null | head -1)
+        docx_file=$(ls ./docs/*.docx 2>/dev/null | head -1 || true)
         if [ -n "$docx_file" ]; then
-          docx_link="https://github.com/$GITHUB_REPOSITORY/raw/preview-7/$docx_file"
+            docx_link="https://github.com/$GITHUB_REPOSITORY/raw/preview-14/$docx_file"
         else
-          docx_link="NA"
+            docx_link="NA"
         fi
         bookdown_link=$(echo "https://htmlpreview.github.io/?https://raw.githubusercontent.com/$GITHUB_REPOSITORY/preview-${{ github.event.pull_request.number }}/${{ inputs.root_path }}/docs/index.html")
         zip_link=$(echo "https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/${{ inputs.root_path }}/website-preview.zip")

--- a/action.yml
+++ b/action.yml
@@ -135,6 +135,7 @@ runs:
         git commit -m 'Render course' || echo "No changes to commit"
         git status docs/*
         git push --force -u origin main  || echo "No changes to push"
+      shell: bash
 
     - name: Find Comment
       if: ${{ inputs.preview == 'true' }}


### PR DESCRIPTION
## Summary 

Sometimes people don't want to create a docx file -- sometimes there isn't one yet. This shouldn't be a reason to halt everything. 

But this is what was happening over here: https://github.com/fhdsl/reproducibility_capstone/actions/runs/15498275456

I think this should address that? It will provide a broken link and probably more ideally it should just not print out the docx link at all -- but I don't have time to implement all that right now. But this is a start. 