### PR TITLE
Don't have the comment include an NA docx link

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
         fetch-depth: 0
 
     - name: Run render for Rmd
-      uses: ottrproject/ottr-preview@kweav-suppress-docx
+      uses: ottrproject/ottr-preview@cansavvy/no-docx
       with:
         toggle_website: "rmd"
         root_path: test-rmd
 
     - name: Run render for Quarto
-      uses: ottrproject/ottr-preview@kweav-suppress-docx
+      uses: ottrproject/ottr-preview@cansavvy/no-docx
       with:
         toggle_website: "quarto"
         root_path: test-quarto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
         fetch-depth: 0
 
     - name: Run render for Rmd
-      uses: ottrproject/ottr-preview@cansavvy/no-docx
+      uses: ottrproject/ottr-preview@kweav-suppress-docx
       with:
         toggle_website: "rmd"
         root_path: test-rmd
 
     - name: Run render for Quarto
-      uses: ottrproject/ottr-preview@cansavvy/no-docx
+      uses: ottrproject/ottr-preview@kweav-suppress-docx
       with:
         toggle_website: "quarto"
         root_path: test-quarto

--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,7 @@ runs:
       shell: bash
 
     - name: Create or update comment (with docx file)
-      if: ${{ inputs.preview == 'true' && steps.build-components.outputs.docx_link != "NA" }}
+      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link != "NA" }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -185,7 +185,7 @@ runs:
         edit-mode: replace
 
     - name: Create or update comment (without docx file)
-      if: ${{ inputs.preview == 'true' && steps.build-components.outputs.docx_link == "NA" }}
+      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link == "NA" }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
       run: |
         docx_file=$(ls ./docs/*.docx 2>/dev/null | head -1 || true)
         if [ -n "$docx_file" ]; then
-            docx_link="https://github.com/$GITHUB_REPOSITORY/raw/preview-14/$docx_file"
+            docx_link="https://github.com/$GITHUB_REPOSITORY/raw/preview-${{ github.event.pull_request.number }}/$docx_file"
         else
             docx_link="NA"
         fi
@@ -167,8 +167,8 @@ runs:
         echo ${{steps.commit.outputs.changes}}
       shell: bash
 
-    - name: Create or update comment
-      if: ${{ inputs.preview == 'true' }}
+    - name: Create or update comment (with docx file)
+      if: ${{ inputs.preview == 'true' && steps.build-components.outputs.docx_link != "NA" }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -178,6 +178,22 @@ runs:
           - :eyes: Quick [preview of course website here](${{ steps.build-components.outputs.bookdown_link }}) \*
           - :microscope: Comprehensive [download of the course website here](${{ steps.build-components.outputs.zip_link }})
           - Download the [.docx file](${{ steps.build-components.outputs.docx_link }})
+
+          \* note not all html features will be properly displayed in the "quick preview" but it will give you a rough idea.
+
+          _Updated at ${{ steps.build-components.outputs.time }} with changes from the latest commit ${{ steps.build-components.outputs.commit_id }}_
+        edit-mode: replace
+
+    - name: Create or update comment
+      if: ${{ inputs.preview == 'true' && steps.build-components.outputs.docx_link == "NA" }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Re-rendered previews from the latest commit:
+          - :eyes: Quick [preview of course website here](${{ steps.build-components.outputs.bookdown_link }}) \*
+          - :microscope: Comprehensive [download of the course website here](${{ steps.build-components.outputs.zip_link }})
 
           \* note not all html features will be properly displayed in the "quick preview" but it will give you a rough idea.
 

--- a/action.yml
+++ b/action.yml
@@ -184,7 +184,7 @@ runs:
           _Updated at ${{ steps.build-components.outputs.time }} with changes from the latest commit ${{ steps.build-components.outputs.commit_id }}_
         edit-mode: replace
 
-    - name: Create or update comment
+    - name: Create or update comment (without docx file)
       if: ${{ inputs.preview == 'true' && steps.build-components.outputs.docx_link == "NA" }}
       uses: peter-evans/create-or-update-comment@v2
       with:

--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,7 @@ runs:
       shell: bash
 
     - name: Create or update comment (with docx file)
-      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link != "NA" }}
+      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link != 'NA' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -185,7 +185,7 @@ runs:
         edit-mode: replace
 
     - name: Create or update comment (without docx file)
-      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link == "NA" }}
+      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link == 'NA' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
Updating the action fix in PR #14  to suppress the docx part of the comment if there is no docx file, rather than having a URL with "NA" in it displayed in the comment.

This is a little less DRY, but perhaps we can use a [comment template](https://github.com/peter-evans/create-or-update-comment/tree/main?tab=readme-ov-file#using-a-markdown-template) to get around that if it's a concern? 