### PR TITLE
Working on some lingering issue with render-all permissions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,13 +28,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout files
-      if: ${{ inputs.preview == 'true' }}
+      if: inputs.preview == 'true'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Checkout files for rendering on main
-      if: ${{ inputs.preview == 'false' }}
+      if: inputs.preview == 'false'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -52,6 +52,7 @@ runs:
     - name: Set up preview branch
       if: ${{ inputs.preview == 'true' }}
       run: |
+        echo preview selection ${{ inputs.preview == 'true' }}
         git push origin --delete preview-${{ github.event.pull_request.number }} || echo "No branch to delete"
         branch_name='preview-${{ github.event.pull_request.number }}'
         echo branch doesnt exist

--- a/action.yml
+++ b/action.yml
@@ -28,13 +28,13 @@ runs:
   using: "composite"
   steps:
     - name: Checkout files
-      if: inputs.preview == 'true'
+      if: ${{ inputs.preview == 'true' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Checkout files for rendering on main
-      if: inputs.preview == 'false'
+      if: ${{ inputs.preview == 'false' }}
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -52,7 +52,6 @@ runs:
     - name: Set up preview branch
       if: ${{ inputs.preview == 'true' }}
       run: |
-        echo preview selection ${{ inputs.preview == 'true' }}
         git push origin --delete preview-${{ github.event.pull_request.number }} || echo "No branch to delete"
         branch_name='preview-${{ github.event.pull_request.number }}'
         echo branch doesnt exist
@@ -179,7 +178,7 @@ runs:
       shell: bash
 
     - name: Create or update comment (with docx file)
-      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link != 'NA' }}
+      if: ${{ inputs.preview == 'true' && steps.build-components.outputs.docx_link != 'NA' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -196,7 +195,7 @@ runs:
         edit-mode: replace
 
     - name: Create or update comment (without docx file)
-      if: ${{ inputs.preview == 'true' }} && ${{ steps.build-components.outputs.docx_link == 'NA' }}
+      if: ${{ inputs.preview == 'true' && steps.build-components.outputs.docx_link == 'NA' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/action.yml
+++ b/action.yml
@@ -14,13 +14,13 @@ inputs:
     type: string
   preview:
     description: "True or false a preview branch should be created for this. "
-    default: TRUE
+    default: true
     type: boolean
   docker_image:
     description: "The docker image that will be used for rendering"
     default: jhudsl/base_ottr:dev
     type: string
-  token: 
+  token:
     description: "A GitHub personal access token only needed if preview = 'false'. Needs privileges to merge to main."
     type: string
 
@@ -39,7 +39,7 @@ runs:
       with:
         fetch-depth: 0
         token: ${{ inputs.token }}
-      
+
     # Set up git checkout
     - name: Set up git checkout
       run: |
@@ -61,7 +61,7 @@ runs:
         git checkout $branch_name
         git merge -s recursive --strategy-option=theirs origin/${{ github.head_ref }} --allow-unrelated-histories
       shell: bash
-      
+
     # We want a fresh run of the renders each time
     - name: Delete old docs/*
       if: ${{ inputs.preview == 'false' }}
@@ -71,7 +71,7 @@ runs:
         git pull --rebase --allow-unrelated-histories --strategy-option=ours
         rm -rf docs/*
       shell: bash
-          
+
     # Run rendering
     - name: Render Special
       id: render
@@ -156,7 +156,7 @@ runs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: latest commit
-    
+
     - name: Build components of the comment
       if: ${{ inputs.preview == 'true' }}
       id: build-components


### PR DESCRIPTION
Noticed we were still having some issues over here with parts of this composite action running even when they weren't supposed to (parts running even though `inputs.preview == 'false'`). https://github.com/jhudsl/AnVIL_Template/actions/runs/15828961703/job/44616465756

I think this PR addresses the issue. @kweav can you please make sure this still works with the 'rendering without docx' changes you all made?

successful run with these changes: https://github.com/jhudsl/AnVIL_Template/actions/runs/15830792757