### PR TITLE
Switch cwd to docs/ when creating zip to eliminate nested structure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,11 +102,11 @@ runs:
       if: ${{ inputs.preview == 'true' }}
       run: |
         if [ '${{ inputs.root_path }}' != '.' ]; then
-          zip -r ${{ github.workspace }}/${{ inputs.root_path }}/website-preview.zip \
-          ${{ github.workspace }}/${{ inputs.root_path }}/docs/*
+          cd ${{ github.workspace }}/${{ inputs.root_path }}/docs
+          zip -r ${{ github.workspace }}/${{ inputs.root_path }}/website-preview.zip .
         else
-          zip -r ${{ github.workspace }}/website-preview.zip \
-          ${{ github.workspace }}/docs/* -r
+          cd ${{ github.workspace }}/docs
+          zip -r ${{ github.workspace }}/website-preview.zip .
         fi
       shell: bash
 


### PR DESCRIPTION
By default, `zip` will preserve the directory structure of its contents. There is a flag `-j` that will throw away the nesting but that flattens things out entirely which we don't want in this case since `docs/` itself contains directories.

The best way I could think to make this work is to actually switch the working dir to `docs/` before creating the zip. The zip is created at the same location it always was, but now the contents of `docs/` should be at the top level. Testing locally it works as expected but sometimes in the actions runner things act differently so probably want to double check it there.


closes #11 